### PR TITLE
Add body.data available in error response

### DIFF
--- a/jsend-1.2.js
+++ b/jsend-1.2.js
@@ -137,7 +137,7 @@
 					self.onFail.apply(self, [body.data, xhr]);
 					break;
 				case STATUS_ERROR:
-					self.onError.apply(self, [body.message, xhr]);
+					self.onError.apply(self, [body.message, body.data, xhr]);
 					break;
 			}
 			self.onComplete.apply(self, [body, xhr]);


### PR DESCRIPTION
Only the message was available.
Data is optional in JSend but you can't get it when you get an status error returned.
